### PR TITLE
Move register/unregister to onResume/OnPause instead of onStart/onStop

### DIFF
--- a/app/src/main/java/com/blabbertabber/blabbertabber/RecordingActivity.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/RecordingActivity.java
@@ -69,6 +69,14 @@ public class RecordingActivity extends Activity {
     protected void onStart() {
         super.onStart();
         Log.i(TAG, "onStart()");
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        Log.i(TAG, "onResume()");
+        setContentView(R.layout.activity_recording);
+        // kick off the service
         Intent serviceIntent = new Intent(this, RecordingService.class);
         if (bindService(serviceIntent, mServerConn, BIND_AUTO_CREATE)) {
             Log.i(TAG, "bindService() succeeded, mBound: " + mBound);
@@ -78,19 +86,18 @@ public class RecordingActivity extends Activity {
         LocalBroadcastManager.getInstance(this).registerReceiver((mReceiver),
                 new IntentFilter(Recorder.RECORD_RESULT)
         );
-    }
 
-    @Override
-    protected void onResume() {
-        super.onResume();
-        Log.i(TAG, "onResume()");
-        setContentView(R.layout.activity_recording);
     }
 
     @Override
     protected void onPause() {
         super.onPause();
         Log.i(TAG, "onPause()");
+        // unregister
+        LocalBroadcastManager.getInstance(this).unregisterReceiver(mReceiver);
+        if (mServerConn != null) {
+            unbindService(mServerConn);
+        }
         // close-out the current speaker
         stopPreviousSpeaker();
     }
@@ -99,10 +106,6 @@ public class RecordingActivity extends Activity {
     protected void onStop() {
         super.onStop();
         Log.i(TAG, "onStop()");
-        LocalBroadcastManager.getInstance(this).unregisterReceiver(mReceiver);
-        if (mServerConn != null) {
-            unbindService(mServerConn);
-        }
     }
 
     @Override

--- a/app/src/main/java/com/blabbertabber/blabbertabber/Speaker.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/Speaker.java
@@ -64,7 +64,6 @@ public class Speaker implements Comparable<Speaker> {
         }
     }
 
-
     public String getName() {
         return mName;
     }


### PR DESCRIPTION
fixes:

```
Attempt to invoke virtual method 'void android.widget.ImageView.setVisibility(int)' on a null object reference
```

The failed test seems to be caused by a race condition where the background service triggers the RecordingActivity's onReceive() which in turn calls updateSpeakerVolumeView
() but the RecordingActivity has already executed onStop(), so the when we attempt to access any of the Views we get `Attempt to invoke virtual method...`

I have reservations about whether this will fix the problem (though empirically it seems to have worked: I ran the test 20 times without an error). Specifically the fix is to move the unbind() to the onPause() method, which is where I think it should go, but if you look at the stack trace below you will see that onStop() is called ~200ms before onPause() (which is _never_ supposed to happen). In other words, this fix implements the correct behavior, but the stack trace seems to indicate that the lifecycle calls are being implemented out-of-order, so our "wrong" code should have worked.

Stack trace of failing test:

```
11-18 16:52:22.305 8845-8845/com.blabbertabber.blabbertabber I/RecordingActivity: onCreate()
11-18 16:52:22.309 8845-8845/com.blabbertabber.blabbertabber I/RecordingActivity: onStart()
11-18 16:52:22.309 8845-8845/com.blabbertabber.blabbertabber I/RecordingActivity: bindService() succeeded, mBound: false
11-18 16:52:22.310 8845-8845/com.blabbertabber.blabbertabber I/RecordingActivity: onResume()
11-18 16:52:22.317 8845-8845/com.blabbertabber.blabbertabber I/RecordingActivity: onStop()
11-18 16:52:22.338 8845-8856/com.blabbertabber.blabbertabber I/art: Background sticky concurrent mark sweep GC freed 9528(432KB) AllocSpace objects, 1(84KB) LOS objects, 11% free, 3MB/4MB, paused 9.734ms total 93.088ms
11-18 16:52:22.348 8845-8856/com.blabbertabber.blabbertabber W/art: Suspending all threads took: 10.241ms
11-18 16:52:22.351 8845-8845/com.blabbertabber.blabbertabber I/RecordingActivity: onDestroy()
11-18 16:52:22.404 8845-8875/com.blabbertabber.blabbertabber W/EGL_emulation: eglSurfaceAttrib not implemented
11-18 16:52:22.404 8845-8875/com.blabbertabber.blabbertabber W/OpenGLRenderer: Failed to set EGL_SWAP_BEHAVIOR on surface 0xa2bfb6e0, error=EGL_SUCCESS
11-18 16:52:22.408 2036-2053/com.android.launcher3 W/OpenGLRenderer: Incorrectly called buildLayer on View: ShortcutAndWidgetContainer, destroying layer...
11-18 16:52:22.408 2036-2053/com.android.launcher3 W/OpenGLRenderer: Incorrectly called buildLayer on View: ShortcutAndWidgetContainer, destroying layer...
11-18 16:52:22.417 2036-2053/com.android.launcher3 E/Surface: getSlotFromBufferLocked: unknown buffer: 0xa1222000
11-18 16:52:22.526 1279-1298/system_process I/ActivityManager: Displayed com.blabbertabber.blabbertabber/.RecordingActivity: +269ms (total +1s435ms)
11-18 16:52:22.553 937-937/? E/EGL_emulation: tid 937: eglCreateSyncKHR(1243): error 0x3004 (EGL_BAD_ATTRIBUTE)
11-18 16:52:22.580 8845-8845/com.blabbertabber.blabbertabber I/RecordingActivity: onPause()
11-18 16:52:22.581 8845-8859/com.blabbertabber.blabbertabber I/TestRunner: finished: rootViewTest(com.blabbertabber.blabbertabber.RecordingActivityTest)
11-18 16:52:22.593 8845-8845/com.blabbertabber.blabbertabber I/MonitoringInstrumentation: Activities that are still in CREATED to STOPPED: 1
11-18 16:52:22.595 8845-8859/com.blabbertabber.blabbertabber I/TestRunner: started: testCompareto_2(com.blabbertabber.blabbertabber.SpeakerTest)
11-18 16:52:22.609 8845-8845/com.blabbertabber.blabbertabber I/MonitoringInstrumentation: Activities that are still in CREATED to STOPPED: 1
11-18 16:52:22.611 8845-8859/com.blabbertabber.blabbertabber I/TestRunner: finished: testCompareto_2(com.blabbertabber.blabbertabber.SpeakerTest)
11-18 16:52:22.615 8845-8845/com.blabbertabber.blabbertabber I/MonitoringInstrumentation: Activities that are still in CREATED to STOPPED: 1
11-18 16:52:22.616 8845-8859/com.blabbertabber.blabbertabber I/TestRunner: started: testCompareto(com.blabbertabber.blabbertabber.SpeakerTest)
11-18 16:52:22.620 8845-8845/com.blabbertabber.blabbertabber I/MonitoringInstrumentation: Activities that are still in CREATED to STOPPED: 1
11-18 16:52:22.620 8845-8859/com.blabbertabber.blabbertabber I/TestRunner: finished: testCompareto(com.blabbertabber.blabbertabber.SpeakerTest)
11-18 16:52:22.621 8845-8845/com.blabbertabber.blabbertabber I/MonitoringInstrumentation: Activities that are still in CREATED to STOPPED: 1
11-18 16:52:22.621 8845-8859/com.blabbertabber.blabbertabber I/TestRunner: started: testComparetoWithNames(com.blabbertabber.blabbertabber.SpeakerTest)
11-18 16:52:22.622 8845-8845/com.blabbertabber.blabbertabber I/MonitoringInstrumentation: Activities that are still in CREATED to STOPPED: 1
11-18 16:52:22.622 8845-8859/com.blabbertabber.blabbertabber I/TestRunner: finished: testComparetoWithNames(com.blabbertabber.blabbertabber.SpeakerTest)
11-18 16:52:22.622 8845-8845/com.blabbertabber.blabbertabber I/MonitoringInstrumentation: Activities that are still in CREATED to STOPPED: 1
11-18 16:52:22.623 8845-8859/com.blabbertabber.blabbertabber I/TestRunner: started: testIsSingleton(com.blabbertabber.blabbertabber.TheMediaRecorderTest)
11-18 16:52:22.624 8845-8845/com.blabbertabber.blabbertabber I/MonitoringInstrumentation: Activities that are still in CREATED to STOPPED: 1
11-18 16:52:22.624 8845-8859/com.blabbertabber.blabbertabber I/TestRunner: finished: testIsSingleton(com.blabbertabber.blabbertabber.TheMediaRecorderTest)
11-18 16:52:22.625 8845-8845/com.blabbertabber.blabbertabber I/MonitoringInstrumentation: Activities that are still in CREATED to STOPPED: 1
11-18 16:52:22.626 8845-8859/com.blabbertabber.blabbertabber I/TestRunner: started: testIsSingleton(com.blabbertabber.blabbertabber.TheSpeakersTest)
11-18 16:52:22.626 8845-8845/com.blabbertabber.blabbertabber I/MonitoringInstrumentation: Activities that are still in CREATED to STOPPED: 1
11-18 16:52:22.626 8845-8859/com.blabbertabber.blabbertabber I/TestRunner: finished: testIsSingleton(com.blabbertabber.blabbertabber.TheSpeakersTest)
11-18 16:52:22.627 8845-8845/com.blabbertabber.blabbertabber I/MonitoringInstrumentation: Activities that are still in CREATED to STOPPED: 1
11-18 16:52:22.627 8845-8859/com.blabbertabber.blabbertabber I/TestRunner: started: testCanSort(com.blabbertabber.blabbertabber.TheSpeakersTest)
11-18 16:52:22.639 8845-8845/com.blabbertabber.blabbertabber I/MonitoringInstrumentation: Activities that are still in CREATED to STOPPED: 1
11-18 16:52:22.640 8845-8859/com.blabbertabber.blabbertabber I/TestRunner: finished: testCanSort(com.blabbertabber.blabbertabber.TheSpeakersTest)
11-18 16:52:22.642 2036-2053/com.android.launcher3 W/EGL_emulation: eglSurfaceAttrib not implemented
11-18 16:52:22.642 2036-2053/com.android.launcher3 W/OpenGLRenderer: Failed to set EGL_SWAP_BEHAVIOR on surface 0xa16ff380, error=EGL_SUCCESS
11-18 16:52:22.644 8845-8845/com.blabbertabber.blabbertabber I/MonitoringInstrumentation: Activities that are still in CREATED to STOPPED: 1
11-18 16:52:22.644 8845-8859/com.blabbertabber.blabbertabber I/TestRunner: run finished: 40 tests, 0 failed, 0 ignored
11-18 16:52:22.645 8845-8859/com.blabbertabber.blabbertabber I/MonitoringInstrumentation: Unstopped activity count: 1
11-18 16:52:22.662 8845-8875/? E/Surface: getSlotFromBufferLocked: unknown buffer: 0xab7d5860
11-18 16:52:22.681 8845-8845/? I/MonitoringInstrumentation: Activities that are still in CREATED to STOPPED: 1
11-18 16:52:22.682 8845-8845/? E/MonitoringInstrumentation: Exception encountered by: Thread[main,5,main]. Dumping thread state to outputs and pining for the fjords.
11-18 16:52:22.682 8845-8845/? E/MonitoringInstrumentation: java.lang.NullPointerException: Attempt to invoke virtual method 'void android.widget.ImageView.setVisibility(int)' on a null object reference
11-18 16:52:22.682 8845-8845/? E/MonitoringInstrumentation:     at com.blabbertabber.blabbertabber.RecordingActivity.updateSpeakerVolumeView(RecordingActivity.java:156)
11-18 16:52:22.682 8845-8845/? E/MonitoringInstrumentation:     at com.blabbertabber.blabbertabber.RecordingActivity.access$200(RecordingActivity.java:27)
11-18 16:52:22.682 8845-8845/? E/MonitoringInstrumentation:     at com.blabbertabber.blabbertabber.RecordingActivity$2.onReceive(RecordingActivity.java:62)
11-18 16:52:22.682 8845-8845/? E/MonitoringInstrumentation:     at android.support.v4.content.LocalBroadcastManager.executePendingBroadcasts(LocalBroadcastManager.java:297)
11-18 16:52:22.682 8845-8845/? E/MonitoringInstrumentation:     at android.support.v4.content.LocalBroadcastManager.access$000(LocalBroadcastManager.java:46)
11-18 16:52:22.682 8845-8845/? E/MonitoringInstrumentation:     at android.support.v4.content.LocalBroadcastManager$1.handleMessage(LocalBroadcastManager.java:116)
11-18 16:52:22.682 8845-8845/? E/MonitoringInstrumentation:     at android.os.Handler.dispatchMessage(Handler.java:102)
11-18 16:52:22.682 8845-8845/? E/MonitoringInstrumentation:     at android.os.Looper.loop(Looper.java:148)
11-18 16:52:22.682 8845-8845/? E/MonitoringInstrumentation:     at android.app.ActivityThread.main(ActivityThread.java:5417)
11-18 16:52:22.682 8845-8845/? E/MonitoringInstrumentation:     at java.lang.reflect.Method.invoke(Native Method)
11-18 16:52:22.682 8845-8845/? E/MonitoringInstrumentation:     at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
11-18 16:52:22.682 8845-8845/? E/MonitoringInstrumentation:     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
11-18 16:52:22.684 8845-8845/? E/THREAD_STATE:   Thread[Binder_2,5,main]
```
