### PR TITLE
EmulatorRecorder is needed for Mac Pro Emulator

### DIFF
--- a/app/src/main/java/com/blabbertabber/blabbertabber/EmulatorRecorder.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/EmulatorRecorder.java
@@ -1,0 +1,32 @@
+package com.blabbertabber.blabbertabber;
+
+import android.content.Context;
+import android.util.Log;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * Created by cunnie on 10/3/15.
+ * Class that works with an emulator (no microphone)
+ */
+public class EmulatorRecorder extends Recorder {
+
+    public EmulatorRecorder(Context context) {
+        super(context);
+    }
+
+    @Override
+    protected void startRecording() {
+        Log.i(TAG, "startRecording()");
+    }
+
+    @Override
+    protected void stopRecording() {
+        Log.i(TAG, "stopRecording()");
+    }
+
+    @Override
+    public int getSpeakerVolume() {
+        return ThreadLocalRandom.current().nextInt(0, 100);
+    }
+}

--- a/app/src/main/java/com/blabbertabber/blabbertabber/RecordingService.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/RecordingService.java
@@ -3,6 +3,7 @@ package com.blabbertabber.blabbertabber;
 import android.app.Service;
 import android.content.Intent;
 import android.os.Binder;
+import android.os.Build;
 import android.os.IBinder;
 import android.util.Log;
 
@@ -11,7 +12,8 @@ public class RecordingService extends Service {
     private static final String TAG = "RecordingService";
     private final IBinder mBinder = new RecordingBinder();
     private Thread mThreadRecorder;
-    private Recorder mRecorder = new DeviceRecorder(this);
+    // emulator crashes if attempts to use the actual microphone, so we simulate microphone in EmulatorRecorder
+    private Recorder mRecorder = "goldfish".equals(Build.HARDWARE) ? new EmulatorRecorder(this) : new DeviceRecorder(this);
 
     public RecordingService() {
     }


### PR DESCRIPTION
- Mac Pro (Brian) emulator throws exception when trying to capture audio
- MacBook Pro (Brendan) captures audio w/out problem

Fixes:

```
Could not get audio input for record source 0, sample rate 16000, format 0x1, channel mask 0x10, session 14, flags 0
java.lang.IllegalStateException: startRecording() called on an uninitialized AudioRecord.
```
