### PR TITLE
Animation tweaks

### DIFF
--- a/app/src/main/java/com/blabbertabber/blabbertabber/DeviceRecorder.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/DeviceRecorder.java
@@ -40,7 +40,6 @@ public class DeviceRecorder extends Recorder {
     @Override
     public int getSpeakerVolume() {
         int volume = mRecorder.getMaxAmplitude();
-        volume = volume * 100 / 32768;
         Log.v(TAG, "getSpeakerVolume() volume: " + volume);
         return volume;
     }

--- a/app/src/main/java/com/blabbertabber/blabbertabber/DeviceRecorder.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/DeviceRecorder.java
@@ -41,7 +41,7 @@ public class DeviceRecorder extends Recorder {
     public int getSpeakerVolume() {
         int volume = mRecorder.getMaxAmplitude();
         volume = volume * 100 / 32768;
-        Log.i(TAG, "getSpeakerVolume() volume is " + volume);
+        Log.v(TAG, "getSpeakerVolume() volume: " + volume);
         return volume;
     }
 }

--- a/app/src/main/java/com/blabbertabber/blabbertabber/Recorder.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/Recorder.java
@@ -50,7 +50,7 @@ public abstract class Recorder implements Runnable {
         try {
             while (true) {
                 if (isRecording()) {
-                    sleep(50);
+                    sleep(100);
                     Log.v(TAG, "run() Thread ID " + Thread.currentThread().getId());
                     /// TODO: remove getSpeakerId()
                     sendResult(getSpeakerId(), getSpeakerVolume());

--- a/app/src/main/java/com/blabbertabber/blabbertabber/RecordingActivity.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/RecordingActivity.java
@@ -3,6 +3,7 @@ package com.blabbertabber.blabbertabber;
 import android.Manifest;
 import android.animation.AnimatorSet;
 import android.animation.ObjectAnimator;
+import android.animation.PropertyValuesHolder;
 import android.animation.ValueAnimator;
 import android.app.Activity;
 import android.content.BroadcastReceiver;
@@ -245,13 +246,8 @@ public class RecordingActivity extends Activity {
         Log.i(TAG, "stopPreviousSpeaker()");
         if (mPreviousSpeakerId >= 0) {
             // The previous speaker is valid; we are not initializing.
-            // reset the size of the previous speakerBall, and dim it, too
             Speaker previousSpeaker = mSpeakers.speakers[mPreviousSpeakerId];
             previousSpeaker.stopSpeaking();
-//            View previousSpeakerBall = findViewById(previousSpeaker.getViewID());
-//            previousSpeakerBall.setScaleX(1);
-//            previousSpeakerBall.setScaleY(1);
-//            previousSpeakerBall.setAlpha((float) 0.7);
         }
     }
 
@@ -263,20 +259,23 @@ public class RecordingActivity extends Activity {
         }
         Speaker speaker = mSpeakers.speakers[speakerId];
         speaker.startSpeaking();
-//        ImageView speakerBall = (ImageView) findViewById(speaker.getViewID());
-//        speaker.setVisible(View.VISIBLE);
-//        speakerBall.setVisibility(View.VISIBLE);
-//        speakerBall.setAlpha((float) 1.0);
-//        GradientDrawable shape = (GradientDrawable) speakerBall.getDrawable();
-//        if (shape != null) {
-//            shape.setColor(speaker.getColor());
-//        }
-//        speakerBall.requestLayout();
 
-//        PropertyValuesHolder phvx = PropertyValuesHolder.ofFloat(View.SCALE_X, (float) (0.5 + speakerVolume / 80.0));
-//        PropertyValuesHolder phvy = PropertyValuesHolder.ofFloat(View.SCALE_Y, (float) (0.5 + speakerVolume / 80.0));
-//        ObjectAnimator scaleAnimation = ObjectAnimator.ofPropertyValuesHolder(speakerBall, phvx, phvy);
-//        scaleAnimation.setDuration(20).start();
+        // PieSlices are "maxed-out" by default
+        // Max-out corresponds to a 32767 speaker volume
+        // .80 * PieSlice is the min, corresponding to a 0 speaker volume
+        // "goldenRatio" has nothing to do with the Golden Ratio
+        float goldenRatio = (float) (0.2 * (double) speakerVolume / (double) Short.MAX_VALUE + 0.8);
+        Log.d(TAG, "updateSpeakerVolumeView() goldenRatio: " + goldenRatio);
+        PropertyValuesHolder phvx = PropertyValuesHolder.ofFloat(View.SCALE_X, (float) (goldenRatio));
+        PropertyValuesHolder phvy = PropertyValuesHolder.ofFloat(View.SCALE_Y, (float) (goldenRatio));
+
+        ObjectAnimator bScaleAnimation = ObjectAnimator.ofPropertyValuesHolder(bluePieSlice, phvx, phvy).setDuration(20);
+        ObjectAnimator rScaleAnimation = ObjectAnimator.ofPropertyValuesHolder(redPieSlice, phvx, phvy).setDuration(20);
+        ObjectAnimator yScaleAnimation = ObjectAnimator.ofPropertyValuesHolder(yellowPieSlice, phvx, phvy).setDuration(20);
+
+        AnimatorSet ephemeralAnimatorSet = new AnimatorSet();
+        ephemeralAnimatorSet.play(bScaleAnimation).with(rScaleAnimation).with(yScaleAnimation);
+        ephemeralAnimatorSet.start();
     }
 
     @Override

--- a/app/src/main/java/com/blabbertabber/blabbertabber/TheAudioRecord.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/TheAudioRecord.java
@@ -137,7 +137,7 @@ public class TheAudioRecord extends AudioRecord {
                     + " with message " + e.getMessage());
             e.printStackTrace();
         }
-        Log.i(TAG,"getMaxAmplitude() readsize: "+readSize+" maxAmplitude "+maxAmplitude);
+        Log.i(TAG, "getMaxAmplitude() readsize: " + readSize + " maxAmplitude " + maxAmplitude);
         return maxAmplitude;
     }
 }

--- a/app/src/main/java/com/blabbertabber/blabbertabber/TheAudioRecord.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/TheAudioRecord.java
@@ -111,7 +111,6 @@ public class TheAudioRecord extends AudioRecord {
      * The range is that of a signed short.
      */
     public int getMaxAmplitude() {
-        Log.i(TAG, "getMaxAmplitude()");
         int maxAmplitude = Short.MIN_VALUE;
         int readSize = read(AUDIO_DATA, 0, AUDIO_DATA.length);
         byte[] rawAudio = new byte[AUDIO_DATA.length * 2];
@@ -137,7 +136,8 @@ public class TheAudioRecord extends AudioRecord {
                     + " with message " + e.getMessage());
             e.printStackTrace();
         }
-        Log.i(TAG, "getMaxAmplitude() readsize: " + readSize + " maxAmplitude " + maxAmplitude);
+        // Log.v instead of Log.i because this routine is called very, very often
+        Log.v(TAG, "getMaxAmplitude() readsize: " + readSize + " maxAmplitude " + maxAmplitude);
         return maxAmplitude;
     }
 }

--- a/app/src/main/res/layout/activity_recording.xml
+++ b/app/src/main/res/layout/activity_recording.xml
@@ -10,31 +10,29 @@
         android:layout_height="0dp"
         android:layout_weight="4">
 
-
         <com.blabbertabber.blabbertabber.PieSlice xmlns:pie_slice="http://schemas.android.com/apk/res-auto"
-            android:id="@+id/yellow_pie_slice"
+            android:id="@+id/blue_pie_slice"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            pie_slice:pieColor="#b0fee500"
-            pie_slice:startAngle="0"
-            pie_slice:sweepAngle="45" />
+            pie_slice:pieColor="#b00099fe"
+            pie_slice:startAngle="250"
+            pie_slice:sweepAngle="40" />
 
         <com.blabbertabber.blabbertabber.PieSlice xmlns:pie_slice="http://schemas.android.com/apk/res-auto"
             android:id="@+id/red_pie_slice"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             pie_slice:pieColor="#b0fe0019"
-            pie_slice:startAngle="90"
-            pie_slice:sweepAngle="30" />
+            pie_slice:startAngle="245"
+            pie_slice:sweepAngle="50" />
 
         <com.blabbertabber.blabbertabber.PieSlice xmlns:pie_slice="http://schemas.android.com/apk/res-auto"
-            android:id="@+id/blue_pie_slice"
+            android:id="@+id/yellow_pie_slice"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            pie_slice:pieColor="#b00099fe"
-            pie_slice:startAngle="180"
+            pie_slice:pieColor="#b0fee500"
+            pie_slice:startAngle="240"
             pie_slice:sweepAngle="60" />
-
 
         <ImageView
             android:id="@+id/speaker_ball"


### PR DESCRIPTION
Recorder
- changed getSpeakerVolume() call interval from 50ms to 100ms (our frame period is 100ms)

DeviceRecorder
- changed speakerVolume from 0-100 to 0-32767

RecordingActivity's extraneous Toast messages are gone
- removed Toast messages confirming the pressing of buttons--they had
  outlived their usefulness
- refactored onPause() and onResume() code into pause() and record()
- lighter colors on top (yellow), darker on bottom (blue)
- PieSlices' starting point is at the top, so when the animation slows
  it appears that it's fighting gravity, a more natural look
- fixed bug where animations would be frozen if switching back from
  another activity

Changed the severity for frequently-called (more than several times a
second) Log.i() to Log.v().

TheAudioRecord
- removed debugging Log.i()
