### PR TITLE
Diarization shows progressDialog

### DIFF
--- a/app/src/androidTest/java/com/blabbertabber/blabbertabber/HelperTest.java
+++ b/app/src/androidTest/java/com/blabbertabber/blabbertabber/HelperTest.java
@@ -15,6 +15,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
 
 /**
  * Created by cunnie on 11/11/15.
@@ -153,7 +154,7 @@ public class HelperTest {
     // we can write to "/data/user/0/com.blabbertabber.blabbertabber/files/sphinx"
     @Test
     public void testCopyRawToFilesystem00() throws Exception {
-        InputStream inputStream = new ByteArrayInputStream(new String("blah").getBytes(StandardCharsets.UTF_8));
+        InputStream inputStream = new ByteArrayInputStream("blah".getBytes(StandardCharsets.UTF_8));
         File file = new File("/some/nonexistent/directory/sphinx");
 
         exception.expect(IOException.class);
@@ -163,23 +164,48 @@ public class HelperTest {
 
     @Test
     public void testCopyRawToFilesystem01() throws Exception {
-        InputStream inputStream = new ByteArrayInputStream(new String("blah").getBytes(StandardCharsets.UTF_8));
+        InputStream inputStream = new ByteArrayInputStream("blah".getBytes(StandardCharsets.UTF_8));
         File file = new File("sphinx");
 
         exception.expect(IOException.class);
         exception.expectMessage(StringContains.containsString("open failed: EROFS (Read-only file system)"));
         Helper.copyInputFileStreamToFilesystem(inputStream, file.getAbsolutePath());
-        assertEquals("the file is created", file.exists(), true);
+        assertEquals("the file is created", true, file.exists());
     }
 
     @Test
     public void testCopyRawToFilesystem02() throws Exception {
-        InputStream inputStream = new ByteArrayInputStream(new String("blah").getBytes(StandardCharsets.UTF_8));
+        InputStream inputStream = new ByteArrayInputStream("blah".getBytes(StandardCharsets.UTF_8));
         File file = new File("/data/local/tmp/sphinx");
 
         exception.expect(IOException.class);
         exception.expectMessage(StringContains.containsString("open failed: EACCES (Permission denied)"));
         Helper.copyInputFileStreamToFilesystem(inputStream, file.getAbsolutePath());
-        assertEquals("the file is created", file.exists(), true);
+        assertEquals("the file is created", true, file.exists());
+    }
+
+    @Test
+    public void testHowFastIsMyProcessor() {
+        assertTrue("My processor is fast enough", Helper.howFastIsMyProcessor() > 2.0);
+    }
+
+    @Test
+    public void testhowLongWasMeetingInSeconds00() {
+        assertEquals("A 1-second meeting", 1.0, Helper.howLongWasMeetingInSeconds(32_000), 0.001);
+    }
+
+    @Test
+    public void testhowLongWasMeetingInSeconds01() {
+        assertEquals("A 2-second meeting", 2.0, Helper.howLongWasMeetingInSeconds(64_000), 0.001);
+    }
+
+    @Test
+    public void testhowLongWillDiarizationTake00() {
+        assertEquals("A 10-second meeting at 5x speed", 2.0, Helper.howLongWillDiarizationTake(10.0, 5.0), 0.001);
+    }
+
+    @Test
+    public void testhowLongWillDiarizationTake01() {
+        assertEquals("A 20-second meeting at 4x speed", 5.0, Helper.howLongWillDiarizationTake(20.0, 4.0), 0.001);
     }
 }

--- a/app/src/main/java/com/blabbertabber/blabbertabber/AudioEventProcessor.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/AudioEventProcessor.java
@@ -27,12 +27,12 @@ public class AudioEventProcessor implements Runnable, AudioRecord.OnRecordPositi
     public static final int CANT_WRITE_MEETING_FILE = -3;
     public static final String RECORDER_FILENAME_NO_EXTENSION = "meeting";
     public static final String RECORDER_RAW_FILENAME = RECORDER_FILENAME_NO_EXTENSION + ".raw";
-    private static final String TAG = "AudioEventProcessor";
-    private static final int RECORDER_AUDIO_SOURCE = BestMicrophone.getBestMicrophone();
     // http://developer.android.com/reference/android/media/AudioRecord.html
     // "44100Hz is currently the only rate that is guaranteed to work on all devices"
     // 16k samples/sec * 2 bytes/sample = 32kB/sec == 115.2 MB/hour
-    private static final int RECORDER_SAMPLE_RATE_IN_HZ = 16_000;
+    public static final int RECORDER_SAMPLE_RATE_IN_HZ = 16_000;
+    private static final String TAG = "AudioEventProcessor";
+    private static final int RECORDER_AUDIO_SOURCE = BestMicrophone.getBestMicrophone();
     private static final int RECORDER_CHANNEL_CONFIG = AudioFormat.CHANNEL_IN_MONO;
     private static final int RECORDER_AUDIO_FORMAT = AudioFormat.ENCODING_PCM_16BIT;
     private static final int NUM_FRAMES = RECORDER_SAMPLE_RATE_IN_HZ / 5;  // 5 updates/second

--- a/app/src/main/java/com/blabbertabber/blabbertabber/Helper.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/Helper.java
@@ -85,4 +85,64 @@ public class Helper {
         }
         out.close();
     }
+
+    /**
+     * Calculates how fast a processor is. Result is the ratio of speech diarization to
+     * to length of meeting, e.g. a Snapdragon 808 1.8 GHz hexa core 64-bit ARMv8-A takes
+     * 36s to process a 300s meeting, which means its ratio is 8.33333 (i.e. 8.333 x faster
+     * than real time).
+     * <p/>
+     * This number is fuzzy at best. For example, many processors are heterogenous (e.g
+     * Snapdragon 808 has powerful ARM Cortex-A57 and weak ARM Cortex-A53 cores), so if
+     * this benchmark is run on the fast core but later the processing is done on the slow
+     * core, the progress bar will linger at 99% while the slow core trudges along. Throw
+     * frequency-scaling into the mix, and you have a real crapshoot.
+     * <p/>
+     * (the value returned is used to display a progress bar)
+     *
+     * @return double
+     */
+    public static double howFastIsMyProcessor() {
+        double goldenRatio = 65.0; // this has nothing to do with the Golden Ratio
+        double junk = 1.0;
+
+        // This test takes 533 - 555 ms to run on a Snapdragon 808
+        long startTime = System.currentTimeMillis();
+        for (int i = 0; i < 16_384; i++) {
+            for (int j = 0; j < 1_024; j++) {
+                junk = junk * 1.1;
+            }
+            for (int j = 0; j < 1_024; j++) {
+                junk = junk / 1.1;
+            }
+        }
+        long endTime = System.currentTimeMillis();
+
+        long totalTime = endTime - startTime;
+        return (double) totalTime / goldenRatio;
+    }
+
+    /**
+     * Calculates the duration of a meeting based on the file's size in bytes
+     *
+     * @param fileSizeInBytes, typically File(getFilesDir() + "/meeting.raw").size()
+     * @return double
+     */
+    public static double howLongWasMeetingInSeconds(long fileSizeInBytes) {
+        double samplesPerSecond = AudioEventProcessor.RECORDER_SAMPLE_RATE_IN_HZ;
+        double bytesPerSample = 2;
+        return (double) fileSizeInBytes / (samplesPerSecond * bytesPerSample);
+    }
+
+    /**
+     * Calculates how long diarization will take, in seconds. processorSpeed should be the ratio
+     * of diarization speed to recording speed, typically set from howFastIsMyProcessor()
+     *
+     * @param meetingLengthInSeconds
+     * @param processorSpeed
+     * @return double, length in seconds
+     */
+    public static double howLongWillDiarizationTake(double meetingLengthInSeconds, double processorSpeed) {
+        return meetingLengthInSeconds / processorSpeed;
+    }
 }

--- a/app/src/main/java/com/blabbertabber/blabbertabber/MainActivity.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/MainActivity.java
@@ -15,7 +15,10 @@ import android.view.View;
  */
 public class MainActivity extends Activity {
     private static final String TAG = "MainActivity";
+    private static final String PREF_FIRST_TIME = "com.blabbertabber.blabbertabber.first_time";
+    private static final String PREF_PROCESSORSPEED = "com.blabbertabber.blabbertabber.processing";
     public static boolean resetFirstTime = false;
+    public static double processorSpeed = 1.0;
     private boolean mFirstTime = true;
     private int rushLimbaughIsWrongCount = 0;
 
@@ -32,10 +35,17 @@ public class MainActivity extends Activity {
         Log.i(TAG, "onResume()");
         // http://developer.android.com/training/basics/data-storage/shared-preferences.html
         SharedPreferences sharedPref = getPreferences(Context.MODE_PRIVATE);
-        mFirstTime = sharedPref.getBoolean(getString(R.string.first_time), mFirstTime);
+        mFirstTime = sharedPref.getBoolean(PREF_FIRST_TIME, mFirstTime);
+        processorSpeed = (double) sharedPref.getFloat(PREF_PROCESSORSPEED, (float) processorSpeed);
+        Log.i(TAG, "onResume() FirstTime: " + mFirstTime + "; Speed: " + processorSpeed);
 
         if (!mFirstTime && !resetFirstTime) {
             launchRecordingActivity();
+        } else {
+            // calculating processor speed takes 1/2 second, so we only want to incur this penalty
+            // once, ever, and store it as a preference
+            processorSpeed = Helper.howFastIsMyProcessor();
+            Log.i(TAG, "onResume() Speed, first time calculation: " + processorSpeed);
         }
     }
 
@@ -46,7 +56,8 @@ public class MainActivity extends Activity {
 
         SharedPreferences sharedPref = getPreferences(Context.MODE_PRIVATE);
         SharedPreferences.Editor editor = sharedPref.edit();
-        editor.putBoolean(getString(R.string.first_time), mFirstTime);
+        editor.putBoolean(PREF_FIRST_TIME, mFirstTime);
+        editor.putFloat(PREF_PROCESSORSPEED, (float) processorSpeed);
         editor.apply();
     }
 

--- a/app/src/main/res/layout/activity_recording.xml
+++ b/app/src/main/res/layout/activity_recording.xml
@@ -98,5 +98,4 @@
             android:drawableTop="@drawable/ic_stop_24dp" />
 
     </LinearLayout>
-
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="button_pause">pause</string>
     <string name="button_record">record</string>
     <string name="button_reset">reset</string>
+    <string name="performing_diarization">Performing Diarization</string>
 
     <string name="button_new_meeting">New Meeting</string>
     <string name="button_share">Share</string>


### PR DESCRIPTION
- diarization split into separate threads
  - diarize()
  - diarizationProgress()
- processor Speed is calculated first time & stored
- new helper methods
  - how fast is the processor
  - how long did meeting take (based on size of file in bytes)
  - how long will it take to diarize
- cleaned up redundant Strings in test
- AudioEventProcessor.RECORDER_SAMPLE_RATE_IN_HZ is now public

![06_progressdialog](https://cloud.githubusercontent.com/assets/1020675/12818322/337bcff0-cb0b-11e5-8f13-1e6f04b93fa6.png)
