### PR TITLE
BlabberTabber can share its generated files

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ BlabberTabber is an Android Application that performs
 
 | Summary Screen | Recording Screen | Splash Screen |
 |----------------|------------------|---------------|
-| ![summary screen](https://cloud.githubusercontent.com/assets/1020675/11888325/fca259bc-a4f0-11e5-9746-ee5a5b14ef5b.png) | ![recording screen](https://cloud.githubusercontent.com/assets/1020675/12707094/09500698-c844-11e5-9ff9-69a2424ee54f.png) | ![splash screen](http://imgur.com/t8CfYaL.png) |
+| ![summary screen](https://cloud.githubusercontent.com/assets/1020675/11888325/fca259bc-a4f0-11e5-9746-ee5a5b14ef5b.png) | ![recording screen](https://cloud.githubusercontent.com/assets/1020675/12866959/d4bd625e-cc94-11e5-8a67-f6409a672087.png) | ![splash screen](http://imgur.com/t8CfYaL.png) |
 
 ### Acknowledgements
 

--- a/app/src/androidTest/java/com/blabbertabber/blabbertabber/TimerTest.java
+++ b/app/src/androidTest/java/com/blabbertabber/blabbertabber/TimerTest.java
@@ -70,7 +70,7 @@ public class TimerTest {
             e.printStackTrace();
         }
         time = timer.time();
-        assertTrue("Started, time elapsed should return should return '50' milliseconds, +/- 40% " + time, time > 30 && time < 70);
+        assertTrue("Started, time elapsed should return should return '50' milliseconds, < +800% " + time, time > 50 && time < 400);
     }
 
     @Test
@@ -88,7 +88,8 @@ public class TimerTest {
             e.printStackTrace();
         }
         time = timer.time();
-        assertTrue("Started, time elapsed should return should return '50' milliseconds, +/- 40% " + time, time > 30 && time < 70);
+        // emulator
+        assertTrue("Started, time elapsed should return should return '50' milliseconds, < +800%", time > 50 && time < 400);
     }
 
     @Test

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,16 +24,24 @@
         </activity>
         <activity android:name=".RecordingActivity" />
         <activity android:name=".SummaryActivity" />
+        <activity android:name=".AcknowledgementsActivity" />
+        <activity android:name=".SpeakerStatsActivity" />
 
         <service
             android:name=".RecordingService"
             android:enabled="true"
             android:exported="false" />
+        <provider
+            android:name="android.support.v4.content.FileProvider"
+            android:authorities="com.blabbertabber.blabbertabber.fileprovider"
+            android:grantUriPermissions="true"
+            android:exported="false" >
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/filepaths" />
+        </provider>
 
-        <activity
-            android:name=".AcknowledgementsActivity"
-            android:label="@string/title_activity_acknowledgements" />
-        <activity android:name=".SpeakerStatsActivity"></activity>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/blabbertabber/blabbertabber/AudioEventProcessor.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/AudioEventProcessor.java
@@ -196,8 +196,9 @@ public class AudioEventProcessor implements Runnable, AudioRecord.OnRecordPositi
     }
 
     private AudioRecordAbstract createAudioRecord(int recorderAudioSource, int recorderSampleRateInHz, int recorderChannelConfig, int recorderAudioFormat, int recorderBufferSizeInBytes) {
+        Log.wtf(TAG, "createAudioRecord()");
         // emulator crashes if attempts to use the actual microphone, so we simulate microphone in EmulatorRecorder
-        return "goldfish".equals(Build.HARDWARE) ?
+        return ( "goldfish".equals(Build.HARDWARE) || "ranchu".equals(Build.HARDWARE) ) ?
                 new AudioRecordEmulator(recorderAudioSource, recorderSampleRateInHz, recorderChannelConfig, recorderAudioFormat, recorderBufferSizeInBytes) :
                 new AudioRecordReal(recorderAudioSource, recorderSampleRateInHz, recorderChannelConfig, recorderAudioFormat, recorderBufferSizeInBytes);
     }

--- a/app/src/main/java/com/blabbertabber/blabbertabber/RecordingActivity.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/RecordingActivity.java
@@ -285,15 +285,14 @@ public class RecordingActivity extends Activity {
         pause(); // stop the recording and animations
         diarizationProgress();
         final Context context = this;
-        final Thread t = new Thread() {
+        new Thread() {
             @Override
             public void run() {
                 diarize();
                 Intent intent = new Intent(context, SummaryActivity.class);
                 startActivity(intent);
             }
-        };
-        t.start();
+        }.start();
     }
 
     private void stopPreviousSpeaker() {

--- a/app/src/main/java/com/blabbertabber/blabbertabber/SpeakerStatsActivity.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/SpeakerStatsActivity.java
@@ -1,7 +1,10 @@
 package com.blabbertabber.blabbertabber;
 
 import android.app.Activity;
+import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
+import android.view.View;
 import android.widget.TextView;
 
 import java.io.BufferedInputStream;
@@ -11,21 +14,30 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
+import static android.support.v4.content.FileProvider.getUriForFile;
+
 public class SpeakerStatsActivity extends Activity {
+    // We don't want to attempt to display a 1.5MB binary .wav file
+    // 32kB is enough to get a sense of what we're looking at
+    private static final int MAX_DISPLAY_SIZE = 32_768;
+    private String filePathName;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_speaker_stats);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
         TextView tv = (TextView) findViewById(R.id.speakerStatView);
-        String filePathName = getIntent().getExtras().getString("path");
-//        String filePathName = getFilesDir() + "/" + AudioEventProcessor.RECORDER_FILENAME_NO_EXTENSION + ".mfc";
+
+        filePathName = getIntent().getExtras().getString("path");
         try {
-            File file = new File(filePathName);
-            int size = (int) file.length();
-            byte[] bytes = new byte[size];
+            byte[] bytes = new byte[MAX_DISPLAY_SIZE];
             InputStream input = new BufferedInputStream(new FileInputStream(filePathName));
-            input.read(bytes, 0, bytes.length);
+            input.read(bytes, 0, MAX_DISPLAY_SIZE);
             CharSequence fileContents = new String(bytes);
             tv.setText(fileContents);
         } catch (FileNotFoundException e) {
@@ -35,6 +47,18 @@ public class SpeakerStatsActivity extends Activity {
             e.printStackTrace();
             tv.setText("IOException: " + e.getMessage());
         }
+    }
 
+    public void share(View view) {
+        File fileToShare = new File(filePathName);
+        Uri fileToShareUri = getUriForFile(getApplicationContext(),
+                "com.blabbertabber.blabbertabber.fileprovider", fileToShare);
+
+        Intent intent = new Intent();
+        intent.setAction(Intent.ACTION_SEND);
+        intent.putExtra(Intent.EXTRA_STREAM, fileToShareUri);
+        intent.putExtra(Intent.EXTRA_SUBJECT, "BlabberTabber_" + fileToShare.getName());
+        intent.setType("application/octet-stream");
+        startActivity(intent);
     }
 }

--- a/app/src/main/java/com/blabbertabber/blabbertabber/SummaryActivity.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/SummaryActivity.java
@@ -164,6 +164,16 @@ public class SummaryActivity extends Activity {
         startActivity(sendIntent);
     }
 
+    public void showRawFile(MenuItem menuItem) {
+        String path = getFilesDir() + "/" + AudioEventProcessor.RECORDER_FILENAME_NO_EXTENSION + ".raw";
+        launchSpeakerStatsActivity(path);
+    }
+
+    public void showWavFile(MenuItem menuItem) {
+        String path = getFilesDir() + "/" + AudioEventProcessor.RECORDER_FILENAME_NO_EXTENSION + ".wav";
+        launchSpeakerStatsActivity(path);
+    }
+
     public void showMfcFile(MenuItem menuItem) {
         String path = getFilesDir() + "/" + AudioEventProcessor.RECORDER_FILENAME_NO_EXTENSION + ".mfc";
         launchSpeakerStatsActivity(path);

--- a/app/src/main/res/drawable/ic_skip_previous_black_24dp.xml
+++ b/app/src/main/res/drawable/ic_skip_previous_black_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="72dp"
+    android:height="72dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M6,6h2v12L6,18zM9.5,12l8.5,6L18,6z" />
+</vector>

--- a/app/src/main/res/layout/activity_recording.xml
+++ b/app/src/main/res/layout/activity_recording.xml
@@ -62,8 +62,8 @@
                 style="?android:attr/borderlessButtonStyle"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:onClick="togglePauseRecord"
                 android:drawableTop="@drawable/ic_play_arrow_24dp"
+                android:onClick="togglePauseRecord"
                 android:text="@string/button_record"
                 android:visibility="invisible" />
 
@@ -72,9 +72,9 @@
                 style="?android:attr/borderlessButtonStyle"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
+                android:drawableTop="@drawable/ic_pause_24dp"
                 android:onClick="togglePauseRecord"
-                android:text="@string/button_pause"
-                android:drawableTop="@drawable/ic_pause_24dp" />
+                android:text="@string/button_pause" />
         </FrameLayout>
 
         <Button
@@ -83,9 +83,9 @@
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"
+            android:drawableTop="@drawable/ic_skip_previous_black_24dp"
             android:onClick="reset"
-            android:text="@string/button_reset"
-            android:drawableTop="@drawable/ic_fast_rewind_24dp" />
+            android:text="@string/button_reset" />
 
         <Button
             android:id="@+id/button_finish"
@@ -93,9 +93,9 @@
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="1"
+            android:drawableTop="@drawable/ic_stop_24dp"
             android:onClick="summary"
-            android:text="@string/button_finish"
-            android:drawableTop="@drawable/ic_stop_24dp" />
+            android:text="@string/button_finish" />
 
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/activity_speaker_stats.xml
+++ b/app/src/main/res/layout/activity_speaker_stats.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     android:paddingBottom="@dimen/activity_vertical_margin"
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
@@ -11,14 +12,23 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="0dp"
+        android:layout_weight="1">
 
         <TextView
             android:id="@+id/speakerStatView"
             android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_height="wrap_content"
             android:text="Small Text"
             android:textAppearance="?android:attr/textAppearanceSmall" />
 
     </ScrollView>
-</RelativeLayout>
+
+    <Button
+        android:id="@+id/button_stats_share"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:onClick="share"
+        android:text="@string/button_share" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_summary.xml
+++ b/app/src/main/res/layout/activity_summary.xml
@@ -429,5 +429,5 @@
         android:layout_gravity="start"
         android:choiceMode="singleChoice"
         app:headerLayout="@layout/drawer_header"
-        app:menu="@menu/drawer"></android.support.design.widget.NavigationView>
+        app:menu="@menu/drawer" />
 </android.support.v4.widget.DrawerLayout>

--- a/app/src/main/res/menu/drawer.xml
+++ b/app/src/main/res/menu/drawer.xml
@@ -10,6 +10,14 @@
             android:onClick="launchMainActivity"
             android:title="@string/launch_main_activity" />
         <item
+            android:id="@+id/show_raw"
+            android:onClick="showRawFile"
+            android:title="@string/show_raw_file" />
+        <item
+            android:id="@+id/show_wav"
+            android:onClick="showWavFile"
+            android:title="@string/show_wav_file" />
+        <item
             android:id="@+id/show_mfc_file"
             android:onClick="showMfcFile"
             android:title="@string/show_mfc_file" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -33,6 +33,8 @@
     <string name="play_meeting_wav">Replay Meeting</string>
     <string name="launch_main_activity">Show Splash Screen</string>
     <string name="launch_speakerstats_activity">Speaker Statistics</string>
+    <string name="show_raw_file">Show .raw File</string>
+    <string name="show_wav_file">Show .wav File</string>
     <string name="show_mfc_file">Show .mfc File</string>
     <string name="show_uem_seg_file">Show .uem.seg File</string>
     <string name="show_s_seg_file">Show .s.seg File</string>

--- a/app/src/main/res/xml/filepaths.xml
+++ b/app/src/main/res/xml/filepaths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <files-path path="" name="artifacts" />
+</paths>

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.5.0'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Aug 02 10:41:29 EDT 2015
+#Sat Feb 06 02:51:43 PST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
- uses FileProvider.getUriForFile()
- displaying a file is limited to 32k (~16 screens)
  (didn't want to exhaust RAM displaying a 1.5MB .wav file)
- changed "reset meeting" icon from rewind to skip_previous
- Updated from Android Studio 1.5 to Android Studio 2 beta2
- adjusted for Android Studio 2.0's emulator's Build.HARDWARE changing from "goldfish" to "ranchu"
- RecordingActivity creates an anonymous thread (fewer variables)
- TimerTest is more forgiving, waits as long as 400ms
  (we had been seeing intermittent failures on emulator)
- Updated README's screenshots

![07_navdrawer](https://cloud.githubusercontent.com/assets/1020675/12866960/d4c0f0e0-cc94-11e5-9cfb-6ea2557634f2.png)
![07_recording](https://cloud.githubusercontent.com/assets/1020675/12866959/d4bd625e-cc94-11e5-8a67-f6409a672087.png)
