### PR TITLE
TimerTest are more informative; upgrade to Studio 2 beta 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+***Warning: although this app is under active development, it does not yet work.***
+
 # BlabberTabber
 
 <!--
@@ -32,6 +34,10 @@ which libraries to use.
 
 * Vaquero, C., Vinyals, O., and Friedland, G.,
   *[A Hybrid Approach to Online Speaker Diarization](http://www.icsi.berkeley.edu/pubs/speech/hybridapproach10.pdf)*,  INTERSPEECH, page 2638-2641. ISCA, (2010)
+
+* Friedland, G., Janin, A., Imseng, D., Anguera, X., Gottlieb, L, Huijbregts, M., Tai Knox, M. Vinyals, O.
+  *[The ICSI RT-09 Speaker Diarization System](http://www.icsi.berkeley.edu/pubs/speech/rt09speaker11.pdf)*,
+  IEEE Transactions on Audio, Speech, and Language Processing, 2/1/12
 
 * Gonina E., Friedland G., Cook H., Keutzer K., *[Fast Speaker Diarization Using a High-Level Scripting Language](https://www.eecs.berkeley.edu/~hcook/papers/gmm_asru2011.pdf)*, In Proc. of ASRU Workshop, 2011.
 

--- a/app/src/androidTest/java/com/blabbertabber/blabbertabber/HelperTest.java
+++ b/app/src/androidTest/java/com/blabbertabber/blabbertabber/HelperTest.java
@@ -15,7 +15,8 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
 import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 
 /**
  * Created by cunnie on 11/11/15.
@@ -186,7 +187,7 @@ public class HelperTest {
 
     @Test
     public void testHowFastIsMyProcessor() {
-        assertTrue("My processor is fast enough", Helper.howFastIsMyProcessor() > 2.0);
+        assertThat("My processor is fast enough", Helper.howFastIsMyProcessor(), greaterThan(2.0));
     }
 
     @Test

--- a/app/src/androidTest/java/com/blabbertabber/blabbertabber/TimerTest.java
+++ b/app/src/androidTest/java/com/blabbertabber/blabbertabber/TimerTest.java
@@ -7,7 +7,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
 
 /**
  * Created by cunnie on 11/11/15.
@@ -38,7 +40,8 @@ public class TimerTest {
             e.printStackTrace();
         }
         time = timer.time();
-        assertTrue("Started, time elapsed should return should return '50' milliseconds, +/- 40% " + time, time > 30 && time < 70);
+        assertThat("Started, time elapsed should return should be greater than 49 ms", time, greaterThan(49L));
+        assertThat("Started, time elapsed should return should be less than 60 ms", time, lessThan(60L));
     }
 
     @Test
@@ -70,7 +73,8 @@ public class TimerTest {
             e.printStackTrace();
         }
         time = timer.time();
-        assertTrue("Started, time elapsed should return should return '50' milliseconds, < +800% " + time, time > 50 && time < 400);
+        assertThat("Started, time elapsed should return should be greater than 49 ms", time, greaterThan(49L));
+        assertThat("Started, time elapsed should return should be less than 60 ms", time, lessThan(60L));
     }
 
     @Test
@@ -88,8 +92,8 @@ public class TimerTest {
             e.printStackTrace();
         }
         time = timer.time();
-        // emulator
-        assertTrue("Started, time elapsed should return should return '50' milliseconds, < +800%", time > 50 && time < 400);
+        assertThat("Started, time elapsed should return should be greater than 49 ms", time, greaterThan(49L));
+        assertThat("Started, time elapsed should return should be less than 60 ms", time, lessThan(60L));
     }
 
     @Test
@@ -115,7 +119,8 @@ public class TimerTest {
             e.printStackTrace();
         }
         time = timer.time();
-        assertTrue("Started, time elapsed should return should return '50' milliseconds, +/- 40% " + time, time > 30 && time < 70);
+        assertThat("Started, time elapsed should return should be greater than 49 ms", time, greaterThan(49L));
+        assertThat("Started, time elapsed should return should be less than 60 ms", time, lessThan(60L));
     }
 
     @Test
@@ -145,6 +150,7 @@ public class TimerTest {
             e.printStackTrace();
         }
         time = timer.time();
-        assertTrue("Started, time elapsed should return should return '100' milliseconds, +/- 40% " + time, time > 70 && time < 130);
+        assertThat("Started, time elapsed should return should be greater than 99 ms", time, greaterThan(99L));
+        assertThat("Started, time elapsed should return should be less than 110 ms", time, lessThan(110L));
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta2'
+        classpath 'com.android.tools.build:gradle:2.0.0-beta4'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
New test will say by how much it failed, rather than the previous,
cryptic expected-true-but-was-false:

```
java.lang.AssertionError: Started, time elapsed should return should be
less than 60 ms
Expected: a value less than <60L>
but: <66L> was greater than <60L>
```

The impetus for making this change was when the pre-tweaked test was failing I was mistakenly increasing the upper bound instead of the lower bound because the test wasn't informative.
