### PR TITLE
Durations and Percents are calculated correctly

### DIFF
--- a/app/src/androidTest/java/com/blabbertabber/blabbertabber/SummaryActivityTest.java
+++ b/app/src/androidTest/java/com/blabbertabber/blabbertabber/SummaryActivityTest.java
@@ -13,6 +13,7 @@ import static android.support.test.espresso.matcher.ViewMatchers.isClickable;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static junit.framework.Assert.assertEquals;
 import static org.hamcrest.Matchers.not;
 
 /**
@@ -64,5 +65,12 @@ public class SummaryActivityTest {
         for (int i = 0; i < drawerItems.length; i++) {
             onView(withText(drawerItems[i])).check(matches(not(isDisplayed())));
         }
+    }
+
+    @Test
+    public void speakerDurationAndPercentTest() {
+        assertEquals("60,000ms meeting and 600cs speaker should return ' 6 (10%) '(",
+                "        6 (10%) ",
+                SummaryActivity.speakerDurationAndPercent(600L, 60_000L));
     }
 }

--- a/app/src/main/java/com/blabbertabber/blabbertabber/Helper.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/Helper.java
@@ -48,7 +48,7 @@ public class Helper {
      * Converts time to a string, e.g. "1:59:30"
      * or "3.6" or "5:33".
      *
-     * @param milliseconds Time in millseconds since start of meeting
+     * @param milliseconds Time in milliseconds since start of meeting
      * @return String formatted time interval string in "H:MM:SS" format.
      */
     public static String timeToHMMSS(long milliseconds) {


### PR DESCRIPTION
- calculated meeting duration based on .raw file size instead of the completely incorrect .l.seg file size.
- the meeting's duration/average/min/max are displayed in H:MM:SS[s] format
- individual speaker's time & percent are displayed
- individual speaker's time & percent are extracted to a tested method
- fixed typo "milliseconds"
- placated IDE with Locale.getDefault()

Through testing it appears that "features" correspond to hundredths of a second.
We ran a test meeting of 57400ms (57.4 seconds) and came up with 5738 features (4,606 + 1132):

57400ms / 5738 features = 10.003485535ms/feature

Lingering questions:
- should we extract the methods in Helper class to a more-specific StringsAndDurations class?
- should we move speakerDurationAndPercent() to that class?

BEFORE:

![screenshot_20160216-071422](https://cloud.githubusercontent.com/assets/1020675/13080326/11589216-d47d-11e5-84d2-0b34d1528f96.png)

AFTER:

![screenshot_20160216-071212](https://cloud.githubusercontent.com/assets/1020675/13080325/11534432-d47d-11e5-85c6-3778cff50c9f.png)
