### PR TITLE
No dropped audio

### DIFF
--- a/app/src/androidTest/java/com/blabbertabber/blabbertabber/AudioRecordEmulatorTest.java
+++ b/app/src/androidTest/java/com/blabbertabber/blabbertabber/AudioRecordEmulatorTest.java
@@ -1,0 +1,45 @@
+package com.blabbertabber.blabbertabber;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * Created by cunnie on 4/10/16.
+ */
+@RunWith(AndroidJUnit4.class)
+public class AudioRecordEmulatorTest {
+    static final int ARRAYSIZE = 16;
+
+    @Test
+    public void readReturnsRandomData() {
+        int recorderBufferSizeInBytes = ARRAYSIZE * 2; // 2 bytes per short
+        short[] audioData = new short[ARRAYSIZE];
+        Arrays.fill(audioData, (short) 0);
+
+        AudioRecordEmulator audioRecordEmulator = new AudioRecordEmulator(0, 0, 0, 0, recorderBufferSizeInBytes);
+        long startTime = System.currentTimeMillis();
+        int framesRead = audioRecordEmulator.read(audioData, 0, ARRAYSIZE);
+        long endTime = System.currentTimeMillis();
+        assertEquals("We expect to see " + ARRAYSIZE + " frames", ARRAYSIZE, framesRead);
+        assertFalse("read() populates the array with randomData", isArrayAllZeroes(audioData));
+        // when the sleep() is commented-out we get a delay of 0ms
+        assertTrue("We expect a delay of at least 2ms", endTime - startTime > 2);
+    }
+
+    boolean isArrayAllZeroes(short[] PCM) {
+        for (short s : PCM) {
+            if (s != 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/app/src/main/java/com/blabbertabber/blabbertabber/AudioRecordAbstract.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/AudioRecordAbstract.java
@@ -10,10 +10,6 @@ public abstract class AudioRecordAbstract {
 
     protected abstract void stopAndRelease();     // stops the recording, closes file, cannot resume after stop().
 
-    public abstract void setRecordPositionUpdateListener(AudioEventProcessor audioEventProcessor);
-
-    public abstract int setPositionNotificationPeriod(int numFrames);
-
     public abstract void startRecording();
 
     public abstract int read(short[] audioData, int offsetInShorts, int sizeInShorts);

--- a/app/src/main/java/com/blabbertabber/blabbertabber/AudioRecordAbstract.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/AudioRecordAbstract.java
@@ -15,4 +15,6 @@ public abstract class AudioRecordAbstract {
     public abstract int setPositionNotificationPeriod(int numFrames);
 
     public abstract void startRecording();
+
+    public abstract int read(short[] audioData, int offsetInShorts, int sizeInShorts);
 }

--- a/app/src/main/java/com/blabbertabber/blabbertabber/AudioRecordEmulator.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/AudioRecordEmulator.java
@@ -23,40 +23,12 @@ public class AudioRecordEmulator extends AudioRecordAbstract {
 
     @Override
     protected void stopAndRelease() {
-        notifier.interrupt();
-    }
-
-    @Override
-    public void setRecordPositionUpdateListener(AudioEventProcessor audioEventProcessor) {
-        this.audioEventProcessor = audioEventProcessor;
-    }
-
-    @Override
-    public int setPositionNotificationPeriod(int numFrames) {
-        return 0;
+        Log.i(TAG, "stopAndRelease()");
     }
 
     @Override
     public void startRecording() {
-        Log.i(TAG, "startRecording()   About to creat and start thread.");
-
-        /// start new thread
-        notifier = new Thread() {
-            public void run() {
-                while (true) {
-                    try {
-                        Thread.currentThread();
-                        sleep(1000 / AudioEventProcessor.UPDATES_PER_SECOND);
-                        audioEventProcessor.onPeriodicNotification(mRandomAudioData);
-                    } catch (InterruptedException e) {
-                        Log.i(TAG, "run()   Huh.  InterruptedException thrown while sleep()ing.");
-                        e.printStackTrace();
-                        return;
-                    }
-                }
-            }
-        };
-        notifier.start();
+        Log.i(TAG, "startRecording()");
     }
 
     @Override

--- a/app/src/main/java/com/blabbertabber/blabbertabber/AudioRecordEmulator.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/AudioRecordEmulator.java
@@ -58,4 +58,17 @@ public class AudioRecordEmulator extends AudioRecordAbstract {
         };
         notifier.start();
     }
+
+    @Override
+    public int read(short[] audioData, int offsetInShorts, int sizeInShorts) {
+        try {
+            System.arraycopy(mRandomAudioData, 0, audioData, offsetInShorts, sizeInShorts);
+            Thread.sleep(1000 / AudioEventProcessor.UPDATES_PER_SECOND);
+        } catch (InterruptedException e) {
+            Log.i(TAG, "run() InterruptedException thrown while sleep()ing.");
+            e.printStackTrace();
+            return 0;
+        }
+        return sizeInShorts;
+    }
 }

--- a/app/src/main/java/com/blabbertabber/blabbertabber/AudioRecordReal.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/AudioRecordReal.java
@@ -69,4 +69,10 @@ public class AudioRecordReal extends AudioRecordAbstract {
             Log.wtf(TAG, "startRecording() " + e.getClass().getName() + ": " + e.getMessage());
         }
     }
+
+    @Override
+    public int read(short[] audioData, int offsetInShorts, int sizeInShorts) {
+        return audioRecord.read(audioData, offsetInShorts, sizeInShorts);
+    }
+
 }

--- a/app/src/main/java/com/blabbertabber/blabbertabber/AudioRecordReal.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/AudioRecordReal.java
@@ -41,21 +41,7 @@ public class AudioRecordReal extends AudioRecordAbstract {
         audioRecord.stop();
         audioRecord.release();
         audioRecord = new AudioRecord(recorderAudioSource, recorderSampleRateInHz, recorderChannelConfig, recorderAudioFormat, recorderBufferSizeInBytes);
-        audioRecord.setRecordPositionUpdateListener(audioEventProcessor);
-        audioRecord.setPositionNotificationPeriod(numFrames);
         Log.i(TAG, "stopAndRelease() audioRecord: " + audioRecord);
-    }
-
-    @Override
-    public void setRecordPositionUpdateListener(AudioEventProcessor audioEventProcessor) {
-        AudioRecordReal.audioEventProcessor = audioEventProcessor;
-        audioRecord.setRecordPositionUpdateListener(audioEventProcessor);
-    }
-
-    @Override
-    public int setPositionNotificationPeriod(int numFrames) {
-        AudioRecordReal.numFrames = numFrames;
-        return audioRecord.setPositionNotificationPeriod(numFrames);
     }
 
     @Override


### PR DESCRIPTION
Fixes: `W/AudioFlinger: RecordThread: buffer overflow`

Saving recorded audio to file is done in background thread.

The best part: **45 lines new test coverage, 30 fewer lines of code!**
- removed the now-unneeded routines:
  - setRecordPositionUpdateListener
  - onMarkerReached
  - onPeriodicNotification
- AudioRecordAbstract has read() method 
  - has test
  - makes AudioRecordAbstract more full-fledged AudioRecord encapsulator which lays the groundwork for writing audio data to a file in the background thread.
