### PR TITLE
Test rotation and timer during RecordingActivity

### DIFF
--- a/app/src/androidTest/java/com/blabbertabber/blabbertabber/WavFileTest.java
+++ b/app/src/androidTest/java/com/blabbertabber/blabbertabber/WavFileTest.java
@@ -34,5 +34,4 @@ public class WavFileTest {
         String wavFileName = WavFile.convertFilenameFromRawToWav(fileName);
         assertEquals("The .wav extension is added even if the original file's extension is raw", "/dir1/dir2/file.Xraw.wav", wavFileName);
     }
-
 }

--- a/app/src/main/java/com/blabbertabber/blabbertabber/AudioEventProcessor.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/AudioEventProcessor.java
@@ -179,13 +179,14 @@ public class AudioEventProcessor implements Runnable {
                             break;
                     }
                 }
-            }
-
-            try {
-                Thread.sleep(200);
-            } catch (InterruptedException e) {
-                Log.i(TAG, "run()   Huh.  InterruptedException thrown while sleep()ing.");
-                e.printStackTrace();
+            } else {
+                // sleep while not recording rather than spinning like crazy
+                try {
+                    Thread.sleep(1000 / AudioEventProcessor.UPDATES_PER_SECOND);
+                } catch (InterruptedException e) {
+                    Log.i(TAG, "run()   Huh.  InterruptedException thrown while sleep()ing.");
+                    e.printStackTrace();
+                }
             }
         }
     }


### PR DESCRIPTION
- ensures that _Timer_ doesn't jump ahead or fall behind when rotating
- works for both real recording and emulated recording
- AudioEventProcessor doesn't `sleep()` if recording.
  `AudioRecordEmulator#read()` is a sub-optimal emulation of `AudioRecord#read()`.
  If are any other sleeps in the same thread it'll slow down the throughput
  (e.g. you won't get 16k shorts/sec; instead you might get 8k shorts/sec).
  The alternative, spawning a separate thread, seemed overly complex.
  This has caused problems with the tests because the Timer is way off
  when rotated.
- Use `ActivityTestRule`, not `ActivityInstrumentationTestCase2`. It's
  newer, it's less complex, and it's run when _all_ the tests are run.
  (_ActivityInstrumentationTestCase2_ tests were mysteriously skipped when
  all the tests were run)
