### PR TITLE
BlabberTabber does NOT crash when server disconnects

### DIFF
--- a/app/src/main/java/com/blabbertabber/blabbertabber/RecordingActivity.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/RecordingActivity.java
@@ -429,7 +429,6 @@ public class RecordingActivity extends Activity {
             DialogFragment uhOh = new UnreachableServerDialog();
             uhOh.setArguments(connErrBundle);
             uhOh.show(getFragmentManager(), "unreachableTag");
-            uploadProgressBar.setVisibility(View.INVISIBLE);
         } finally {
             diarizerConnection.disconnect();
         }


### PR DESCRIPTION
- When the server disconnects (i.e. crashes), the thread that's doing
the uploading attempts to turn the ProgressBar invisible (it's no longer
necessary, there's no progress)
- Unfortunately, this triggers an error: `Only the original thread that created a view hierarchy can touch its views.`

Our solution is to simply not bother trying to turn the ProgressBar
off. Admittedly, we could put some engineering into turning the
ProgressBar off, but I don't think it's worth it for this corner-case
(i.e. the App is broken, can't upload the sound file, so the cosmetic
presence of a ProgressBar is dwarfed by the non-functioning app)>

fixes:
```
09-17 07:18:31.989 969-2112/com.blabbertabber.blabbertabber I/RecordingActivity: addFilePart()
09-17 07:18:32.110 969-2112/com.blabbertabber.blabbertabber W/RecordingActivity: Caught IOException: unexpected end of stream on Connection{test.diarizer.com:8080, proxy=DIRECT hostAddress=2001:19f0:8001:2e4:: cipherSuite=none protocol=http/1.1} (recycle count=0)
09-17 07:18:32.132 969-969/com.blabbertabber.blabbertabber D/UnreachableServer: onCreateDialog()
09-17 07:18:32.132 969-2112/com.blabbertabber.blabbertabber E/AndroidRuntime: FATAL EXCEPTION: Thread-11
                                                                              Process: com.blabbertabber.blabbertabber, PID: 969
                                                                              android.view.ViewRootImpl$CalledFromWrongThreadException: Only the original thread that created a view hierarchy can touch its views.
                                                                                  at android.view.ViewRootImpl.checkThread(ViewRootImpl.java:6892)
                                                                                  at android.view.ViewRootImpl.invalidateChildInParent(ViewRootImpl.java:1083)
                                                                                  at android.view.ViewGroup.invalidateChild(ViewGroup.java:5205)
                                                                                  at android.view.View.invalidateInternal(View.java:13656)
                                                                                  at android.view.View.invalidate(View.java:13620)
                                                                                  at android.view.View.setFlags(View.java:11527)
                                                                                  at android.view.View.setVisibility(View.java:8069)
                                                                                  at com.blabbertabber.blabbertabber.RecordingActivity.upload(RecordingActivity.java:431)
                                                                                  at com.blabbertabber.blabbertabber.RecordingActivity.access$300(RecordingActivity.java:43)
                                                                                  at com.blabbertabber.blabbertabber.RecordingActivity$4.run(RecordingActivity.java:327)
```