### PR TITLE
Remove Easter Egg "Rush Limbaugh is Wrong"

### DIFF
--- a/app/src/main/java/com/blabbertabber/blabbertabber/MainActivity.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/MainActivity.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.net.Uri;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
@@ -75,22 +74,6 @@ public class MainActivity extends Activity {
     // requirement to pass in a View (which is never used)
     public void launchRecordingActivity(View view) {
         launchRecordingActivity();
-    }
-
-    // Easter Egg for new users
-    public void rushLimbaughIsWrong(View v) {
-        Log.i(TAG, "rushLimbaughIsWrong()");
-        rushLimbaughIsWrongCount += 1;
-        if (rushLimbaughIsWrongCount > 3) {
-            Intent intent = new Intent(Intent.ACTION_VIEW);
-            intent.setData(Uri.parse("https://www.google.com/search?q=rush+limbaugh+wrong"));
-            if (intent.resolveActivity(getPackageManager()) != null) {
-                Log.v(TAG, "rushLimbaughIsWrong(): resolved activity");
-                startActivity(intent);
-            } else {
-                Log.v(TAG, "rushLimbaughIsWrong(): couldn't resolve activity");
-            }
-        }
     }
 
     // needed for testing

--- a/app/src/main/java/com/blabbertabber/blabbertabber/RecordingActivity.java
+++ b/app/src/main/java/com/blabbertabber/blabbertabber/RecordingActivity.java
@@ -442,7 +442,7 @@ public class RecordingActivity extends Activity {
         out.write(("Content-Type: application/octet-stream\r\n").getBytes());
         out.write("\r\n".getBytes());
 
-        uploadProgressBar.setMax((int) soundFileLength/ BLOCK_SIZE);
+        uploadProgressBar.setMax((int) soundFileLength / BLOCK_SIZE);
         Log.e(TAG, "addFilePart(): soundFileLength " + soundFileLength);
         //
         int megabytesUploaded = 0;

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -17,7 +17,6 @@
         android:layout_height="0dp"
         android:layout_gravity="center_horizontal"
         android:layout_weight="1"
-        android:onClick="rushLimbaughIsWrong"
         android:text="@string/welcome_text"
         android:textAppearance="?android:attr/textAppearanceLarge" />
 


### PR DESCRIPTION
If you tap the welcome screen three times, you are redirected to
a Google search for "Rush Limbaugh Wrong". There's only one problem:
the Easter Egg triggers too easily, and the result is confusing.
I watched my co-worker, Tom Dunlap, install BlabberTabber, hit
the "Got it!" button, and then watched him become confused as he
was directed to Google & Rush Limbaugh.

It was funny nine months ago. Nowadays it's not so funny. Remove.